### PR TITLE
Add support for subject token claim mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ $ echo "$ACCESS_TOKEN" | jq '.access_token | split(".") | .[1] | @base64d | from
 
 [jq]: https://stedolan.github.io/jq/
 
+### Claim mapping
+
+DMV supports mapping of subject token claims to issued token claims using [CEL][cel]. `oauth.claimMappings` in the config file defines the mappings of issued token claims to CEL expressions. For example, the following config snippet will map the `infratographer:group` claim based on the `sub` claim:
+
+```yaml
+oauth:
+  claimMappings:
+    "infratographer:group": "claims.sub == '1234' ? 'admin' : 'user'"
+```
+
+The following variables are predefined in the CEL runtime environment:
+
+* `claims`: A dynamic map containing all claims in the subject token JWT. Accessible using `claims.*` (e.g., `claims.sub`)
+* `subSHA256`: The hex-encoded SHA256 sum of the `sub` claim
+
+[cel]: https://github.com/google/cel-go
+
 ### JWKS
 
 The [JSON Web Key Set][jwks] (JWKS) used for signing dmv JWTs is available at `/jwks.json`.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -43,6 +43,11 @@ func serve(ctx context.Context) {
 		logger.Fatalf("error initializing tracing: %s", err)
 	}
 
+	mappingStrategy, err := rfc8693.NewClaimMappingStrategy(config.Config.OAuth.ClaimMappings)
+	if err != nil {
+		logger.Fatalf("error initializing claims mappings: %s", err)
+	}
+
 	jwksStrategy := jwks.NewIssuerJWKSURIStrategy(config.Config.OAuth.SubjectTokenIssuers)
 
 	oauth2Config, err := fositex.NewOAuth2Config(config.Config.OAuth)
@@ -51,6 +56,7 @@ func serve(ctx context.Context) {
 	}
 
 	oauth2Config.IssuerJWKSURIStrategy = jwksStrategy
+	oauth2Config.ClaimMappingStrategy = mappingStrategy
 
 	keyGetter := func(ctx context.Context) (any, error) {
 		return oauth2Config.GetSigningKey(ctx), nil

--- a/dmv.example.yaml
+++ b/dmv.example.yaml
@@ -11,6 +11,8 @@ oauth:
     - keyId: "test"
       algorithm: RS256
       path: /etc/dmv/privkey.pem
+  claimMappings:
+    "infratographer:sub": "'infratographer://example.com/' + subSHA256"
 otel:
   enabled: false
   provider: stdout

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/gin-gonic/gin v1.8.1
+	github.com/google/cel-go v0.13.0
 	github.com/ory/fosite v0.44.0
 	github.com/ory/x v0.0.520
 	github.com/spf13/cobra v1.6.1
@@ -15,6 +16,7 @@ require (
 )
 
 require (
+	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
@@ -72,6 +74,7 @@ require (
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 h1:yL7+Jz0jTC6yykIK/Wh74gnTJnrGr5AyrNMXuA0gves=
+github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -197,6 +199,8 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/cel-go v0.13.0 h1:z+8OBOcmh7IeKyqwT/6IlnMvy621fYUqnTVPEdegGlU=
+github.com/google/cel-go v0.13.0/go.mod h1:K2hpQgEjDp18J76a2DKFRlPBPpgRZgi6EbnpDgIhJ8s=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -332,8 +336,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oleiade/reflections v1.0.1 h1:D1XO3LVEYroYskEsoSiGItp9RUxG6jWnCVvrqH0HHQM=
-github.com/ory/fosite v0.43.0 h1:9H1O3I7CFxS2Y6j9FDAx2W3I5uAyEubc9hECS0UTOgI=
-github.com/ory/fosite v0.43.0/go.mod h1:BTd8+oG1mRtezZbQq0S4D2HBc815bedZHjjs2KRs39Y=
 github.com/ory/fosite v0.44.0 h1:Z3UjyO11/wlIoa3BotOqcTkfm7kUNA8F7dd8mOMfx0o=
 github.com/ory/fosite v0.44.0/go.mod h1:o/G4kAeNn65l6MCod2+KmFfU6JQBSojS7eXys6lKGzM=
 github.com/ory/go-acc v0.2.8 h1:rOHHAPQjf0u7eHFGWpiXK+gIu/e0GRSJNr9pDukdNC4=
@@ -439,6 +441,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.14.0 h1:Rg7d3Lo706X9tHsJMUjdiwMpHB7W8WnSVOssIY+JElU=
 github.com/spf13/viper v1.14.0/go.mod h1:WT//axPky3FdvXHzGw33dNdXXXfFQqmEalje+egj8As=
+github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
+github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/pkg/fositex/config.go
+++ b/pkg/fositex/config.go
@@ -68,7 +68,7 @@ type SigningJWKSProvider interface {
 
 // ClaimMappingStrategy represents a strategy for mapping token claims to other claims.
 type ClaimMappingStrategy interface {
-	MapClaims(claims jwt.JWTClaims) (jwt.JWTClaims, error)
+	MapClaims(claims *jwt.JWTClaims) (jwt.JWTClaimsContainer, error)
 }
 
 // ClaimMappingStrategyProvider represents a provider of a claims mapping strategy.

--- a/pkg/rfc8693/claims.go
+++ b/pkg/rfc8693/claims.go
@@ -1,0 +1,92 @@
+package rfc8693
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/google/cel-go/cel"
+	"github.com/ory/fosite/token/jwt"
+)
+
+const (
+	celVariableClaims    = "claims"
+	celVariableSubSHA256 = "subSHA256"
+)
+
+func parseCEL(input string) (cel.Program, error) {
+	env, err := cel.NewEnv(
+		cel.Variable(celVariableClaims, cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable(celVariableSubSHA256, cel.StringType),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	ast, issues := env.Compile(input)
+	if err := issues.Err(); err != nil {
+		return nil, err
+	}
+
+	prog, err := env.Program(ast)
+	if err != nil {
+		return nil, err
+	}
+
+	return prog, nil
+}
+
+// ClaimMappingStrategy represents a mapping from external identity claims to DMV claims.
+type ClaimMappingStrategy struct {
+	mappings map[string]cel.Program
+}
+
+// NewClaimMappingStrategy creates a ClaimMappingStrategy given a mapping of desired DMV claims to CEL expressions.
+func NewClaimMappingStrategy(mappingExprs map[string]string) (ClaimMappingStrategy, error) {
+	mappings := make(map[string]cel.Program, len(mappingExprs))
+
+	for k, e := range mappingExprs {
+		prog, err := parseCEL(e)
+		if err != nil {
+			return ClaimMappingStrategy{}, err
+		}
+
+		mappings[k] = prog
+	}
+
+	out := ClaimMappingStrategy{
+		mappings: mappings,
+	}
+
+	return out, nil
+}
+
+// MapClaims consumes a set of JWT claims and produces a new set of mapped claims.
+func (m ClaimMappingStrategy) MapClaims(claims jwt.JWTClaims) (jwt.JWTClaims, error) {
+	inputMap := claims.ToMap()
+	outputMap := make(map[string]any, len(m.mappings))
+
+	subSHA256Bytes := sha256.Sum256([]byte(claims.Subject))
+	subSHA256 := hex.EncodeToString(subSHA256Bytes[0:])
+
+	inputEnv := map[string]any{
+		celVariableClaims:    inputMap,
+		celVariableSubSHA256: subSHA256,
+	}
+
+	for k, prog := range m.mappings {
+		out, _, err := prog.Eval(inputEnv)
+
+		if err != nil {
+			return jwt.JWTClaims{}, err
+		}
+
+		outputMap[k] = out.Value()
+	}
+
+	var outputClaims jwt.JWTClaims
+
+	outputClaims.FromMap(outputMap)
+
+	return outputClaims, nil
+}

--- a/pkg/rfc8693/claims.go
+++ b/pkg/rfc8693/claims.go
@@ -71,6 +71,10 @@ func NewClaimMappingStrategy(mappingExprs map[string]string) (ClaimMappingStrate
 
 // MapClaims consumes a set of JWT claims and produces a new set of mapped claims.
 func (m ClaimMappingStrategy) MapClaims(claims *jwt.JWTClaims) (jwt.JWTClaimsContainer, error) {
+	if claims.Subject == "" {
+		return nil, ErrorMissingSub
+	}
+
 	inputMap := claims.ToMapClaims()
 	outputMap := make(map[string]any, len(m.mappings))
 

--- a/pkg/rfc8693/claims.go
+++ b/pkg/rfc8693/claims.go
@@ -70,8 +70,8 @@ func NewClaimMappingStrategy(mappingExprs map[string]string) (ClaimMappingStrate
 }
 
 // MapClaims consumes a set of JWT claims and produces a new set of mapped claims.
-func (m ClaimMappingStrategy) MapClaims(claims jwt.JWTClaims) (jwt.JWTClaims, error) {
-	inputMap := claims.ToMap()
+func (m ClaimMappingStrategy) MapClaims(claims *jwt.JWTClaims) (jwt.JWTClaimsContainer, error) {
+	inputMap := claims.ToMapClaims()
 	outputMap := make(map[string]any, len(m.mappings))
 
 	subSHA256Bytes := sha256.Sum256([]byte(claims.Subject))
@@ -89,7 +89,8 @@ func (m ClaimMappingStrategy) MapClaims(claims jwt.JWTClaims) (jwt.JWTClaims, er
 			wrapped := ErrorCELEval{
 				inner: err,
 			}
-			return jwt.JWTClaims{}, &wrapped
+
+			return nil, &wrapped
 		}
 
 		outputMap[k] = out.Value()
@@ -99,5 +100,5 @@ func (m ClaimMappingStrategy) MapClaims(claims jwt.JWTClaims) (jwt.JWTClaims, er
 
 	outputClaims.FromMap(outputMap)
 
-	return outputClaims, nil
+	return &outputClaims, nil
 }

--- a/pkg/rfc8693/claims.go
+++ b/pkg/rfc8693/claims.go
@@ -25,12 +25,20 @@ func parseCEL(input string) (cel.Program, error) {
 
 	ast, issues := env.Compile(input)
 	if err := issues.Err(); err != nil {
-		return nil, err
+		wrapped := ErrorCELParse{
+			inner: err,
+		}
+
+		return nil, &wrapped
 	}
 
 	prog, err := env.Program(ast)
 	if err != nil {
-		return nil, err
+		wrapped := ErrorCELParse{
+			inner: err,
+		}
+
+		return nil, &wrapped
 	}
 
 	return prog, nil
@@ -78,7 +86,10 @@ func (m ClaimMappingStrategy) MapClaims(claims jwt.JWTClaims) (jwt.JWTClaims, er
 		out, _, err := prog.Eval(inputEnv)
 
 		if err != nil {
-			return jwt.JWTClaims{}, err
+			wrapped := ErrorCELEval{
+				inner: err,
+			}
+			return jwt.JWTClaims{}, &wrapped
 		}
 
 		outputMap[k] = out.Value()

--- a/pkg/rfc8693/claims_test.go
+++ b/pkg/rfc8693/claims_test.go
@@ -1,0 +1,120 @@
+package rfc8693
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/ory/fosite/token/jwt"
+	"github.com/stretchr/testify/assert"
+)
+
+type testFunc[T, U any] func(context.Context, T) testResult[U]
+
+type testResult[U any] struct {
+	success U
+	err     error
+}
+
+type testCase[T, U any] struct {
+	name    string
+	input   T
+	checkFn func(*testing.T, testResult[U])
+}
+
+func runTests[T, U any](ctx context.Context, t *testing.T, cases []testCase[T, U], testFn testFunc[T, U]) {
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := testFn(ctx, testCase.input)
+			testCase.checkFn(t, result)
+		})
+	}
+}
+
+// TestClaimMappingParse checks that claim mapping expressions parse correctly.
+func TestClaimMappingParse(t *testing.T) {
+	runFn := func(ctx context.Context, prog string) testResult[cel.Program] {
+		out, err := parseCEL(prog)
+
+		return testResult[cel.Program]{
+			success: out,
+			err:     err,
+		}
+	}
+
+	testCases := []testCase[string, cel.Program]{
+		{
+			name:  "ParseError",
+			input: "'hello",
+			checkFn: func(t *testing.T, result testResult[cel.Program]) {
+				assert.Nil(t, result.success)
+				assert.NotNil(t, result.err)
+				assert.ErrorIs(t, result.err, &ErrorCELParse{})
+			},
+		},
+		{
+			name:  "Success",
+			input: "'hello! ' + subSHA256",
+			checkFn: func(t *testing.T, result testResult[cel.Program]) {
+				assert.Nil(t, result.err)
+				assert.NotNil(t, result.success)
+			},
+		},
+	}
+
+	runTests(context.Background(), t, testCases, runFn)
+}
+
+// TestClaimMappingEval checks that claim mapping expressions evaluate correctly.
+func TestClaimMappingEval(t *testing.T) {
+	mappingExprs := map[string]string{
+		"plusone":            "1 + claims.num",
+		"infratographer:sub": "'infratographer://example.com/' + subSHA256",
+	}
+
+	strategy, err := NewClaimMappingStrategy(mappingExprs)
+	assert.Nil(t, err)
+
+	runFn := func(ctx context.Context, claims jwt.JWTClaims) testResult[jwt.JWTClaims] {
+		out, err := strategy.MapClaims(claims)
+		return testResult[jwt.JWTClaims]{
+			success: out,
+			err:     err,
+		}
+	}
+
+	testCases := []testCase[jwt.JWTClaims, jwt.JWTClaims]{
+		{
+			name: "RuntimeError",
+			input: jwt.JWTClaims{
+				Subject: "foo",
+				Extra:   map[string]any{},
+			},
+			checkFn: func(t *testing.T, result testResult[jwt.JWTClaims]) {
+				assert.NotNil(t, result.err)
+				assert.ErrorIs(t, result.err, &ErrorCELEval{})
+			},
+		},
+		{
+			name: "Success",
+			input: jwt.JWTClaims{
+				Subject: "foo",
+				Extra: map[string]any{
+					"num": 2,
+				},
+			},
+			checkFn: func(t *testing.T, result testResult[jwt.JWTClaims]) {
+				assert.Nil(t, result.err)
+				expected := jwt.JWTClaims{
+					Extra: map[string]any{
+						"plusone":            int64(3),
+						"infratographer:sub": "infratographer://example.com/2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+					},
+				}
+				assert.Equal(t, expected, result.success)
+			},
+		},
+	}
+
+	runTests(context.Background(), t, testCases, runFn)
+}

--- a/pkg/rfc8693/claims_test.go
+++ b/pkg/rfc8693/claims_test.go
@@ -75,37 +75,38 @@ func TestClaimMappingEval(t *testing.T) {
 	strategy, err := NewClaimMappingStrategy(mappingExprs)
 	assert.Nil(t, err)
 
-	runFn := func(ctx context.Context, claims jwt.JWTClaims) testResult[jwt.JWTClaims] {
+	runFn := func(ctx context.Context, claims *jwt.JWTClaims) testResult[jwt.JWTClaimsContainer] {
 		out, err := strategy.MapClaims(claims)
-		return testResult[jwt.JWTClaims]{
+
+		return testResult[jwt.JWTClaimsContainer]{
 			success: out,
 			err:     err,
 		}
 	}
 
-	testCases := []testCase[jwt.JWTClaims, jwt.JWTClaims]{
+	testCases := []testCase[*jwt.JWTClaims, jwt.JWTClaimsContainer]{
 		{
 			name: "RuntimeError",
-			input: jwt.JWTClaims{
+			input: &jwt.JWTClaims{
 				Subject: "foo",
 				Extra:   map[string]any{},
 			},
-			checkFn: func(t *testing.T, result testResult[jwt.JWTClaims]) {
+			checkFn: func(t *testing.T, result testResult[jwt.JWTClaimsContainer]) {
 				assert.NotNil(t, result.err)
 				assert.ErrorIs(t, result.err, &ErrorCELEval{})
 			},
 		},
 		{
 			name: "Success",
-			input: jwt.JWTClaims{
+			input: &jwt.JWTClaims{
 				Subject: "foo",
 				Extra: map[string]any{
 					"num": 2,
 				},
 			},
-			checkFn: func(t *testing.T, result testResult[jwt.JWTClaims]) {
+			checkFn: func(t *testing.T, result testResult[jwt.JWTClaimsContainer]) {
 				assert.Nil(t, result.err)
-				expected := jwt.JWTClaims{
+				expected := &jwt.JWTClaims{
 					Extra: map[string]any{
 						"plusone":            int64(3),
 						"infratographer:sub": "infratographer://example.com/2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",

--- a/pkg/rfc8693/claims_test.go
+++ b/pkg/rfc8693/claims_test.go
@@ -97,6 +97,19 @@ func TestClaimMappingEval(t *testing.T) {
 			},
 		},
 		{
+			name: "MissingSub",
+			input: &jwt.JWTClaims{
+				Extra: map[string]any{
+					"num": 1,
+				},
+			},
+			checkFn: func(t *testing.T, result testResult[jwt.JWTClaimsContainer]) {
+				assert.NotNil(t, result.err)
+				assert.ErrorIs(t, result.err, ErrorMissingSub)
+			},
+		},
+
+		{
 			name: "Success",
 			input: &jwt.JWTClaims{
 				Subject: "foo",

--- a/pkg/rfc8693/errors.go
+++ b/pkg/rfc8693/errors.go
@@ -1,0 +1,41 @@
+package rfc8693
+
+// ErrorCELParse represents an error during CEL parsing.
+type ErrorCELParse struct {
+	inner error
+}
+
+func (ErrorCELParse) Error() string {
+	return "error parsing CEL expression"
+}
+
+func (e *ErrorCELParse) Is(target error) bool {
+	_, ok := target.(*ErrorCELParse)
+
+	return ok
+}
+
+// Unwrap returns the inner error from CEL parsing.
+func (e *ErrorCELParse) Unwrap() error {
+	return e.inner
+}
+
+// ErrorCELEval represents an error during CEL evaluation.
+type ErrorCELEval struct {
+	inner error
+}
+
+func (ErrorCELEval) Error() string {
+	return "error evaluating CEL expression"
+}
+
+func (e *ErrorCELEval) Is(target error) bool {
+	_, ok := target.(*ErrorCELEval)
+
+	return ok
+}
+
+// Unwrap returns the inner error from CEL evaluation.
+func (e *ErrorCELEval) Unwrap() error {
+	return e.inner
+}

--- a/pkg/rfc8693/errors.go
+++ b/pkg/rfc8693/errors.go
@@ -1,5 +1,16 @@
 package rfc8693
 
+import (
+	"fmt"
+)
+
+var (
+	// ErrorMissingSub represents an error where the 'sub' claim is missing from the input claims.
+	ErrorMissingSub = &ErrorMissingClaim{
+		claim: "sub",
+	}
+)
+
 // ErrorCELParse represents an error during CEL parsing.
 type ErrorCELParse struct {
 	inner error
@@ -40,4 +51,13 @@ func (e *ErrorCELEval) Is(target error) bool {
 // Unwrap returns the inner error from CEL evaluation.
 func (e *ErrorCELEval) Unwrap() error {
 	return e.inner
+}
+
+// ErrorMissingClaim represents an error where a required claim is missing.
+type ErrorMissingClaim struct {
+	claim string
+}
+
+func (e *ErrorMissingClaim) Error() string {
+	return fmt.Sprintf("missing required claim '%s'", e.claim)
 }

--- a/pkg/rfc8693/errors.go
+++ b/pkg/rfc8693/errors.go
@@ -9,6 +9,7 @@ func (ErrorCELParse) Error() string {
 	return "error parsing CEL expression"
 }
 
+// Is returns true if target is a *ErrorCELParse.
 func (e *ErrorCELParse) Is(target error) bool {
 	_, ok := target.(*ErrorCELParse)
 
@@ -29,6 +30,7 @@ func (ErrorCELEval) Error() string {
 	return "error evaluating CEL expression"
 }
 
+// Is returns true if target is a *ErrorCELEval.
 func (e *ErrorCELEval) Is(target error) bool {
 	_, ok := target.(*ErrorCELEval)
 


### PR DESCRIPTION
A number of use cases around token exchange require or are at least made easier by supporting mapping of subject token claims to other, derived claims in the issued token. This commit adds a new fositex type, ClaimMappingStrategy, that defines a mapping from subject token claims to other claims, as well as a CEL-based ClaimMappingStrategy implementation.

In addition to mapping arbitrary claims, the provided CEL implementation supports two special variables:

* `claims`, a map of subject token claims to values
* `subSHA256`, the SHA256 encoding of the subject token sub claim