### PR TITLE
Auto-generate private key when using `docker-up` makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ GOOS=linux
 # use the working dir as the app name, this should be the repo name
 APP_NAME=$(shell basename $(CURDIR))
 
+TEST_PRIVKEY_FILE?=tests/data/privkey.pem
+
 test: | unit-test
 
 unit-test: | lint
@@ -37,7 +39,7 @@ vendor:
 	@go mod download
 	@go mod tidy
 
-docker-up:
+docker-up: $(TEST_PRIVKEY_FILE)
 	@docker-compose build
 	@docker-compose  -f docker-compose.yml up -d app
 
@@ -46,3 +48,6 @@ docker-down:
 
 docker-clean:
 	@docker-compose -f docker-compose.yml down --volumes
+
+$(TEST_PRIVKEY_FILE):
+	openssl genpkey -out $(TEST_PRIVKEY_FILE) -algorithm RSA -pkeyopt rsa_keygen_bits:4096

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ dmv is an OAuth service that supports the following grant types:
 
 dmv is a Go service. To build it, you can either use `make build` to build a Go binary or `make docker-up` to start the Docker Compose service.
 
+The `docker-up` Makefile target will auto-generate a private key and mount it in the container for testing purposes. Note that this is not recommended for actual production use, and is merely a handy feature to allow developers to test.
+
 ### Exchanging tokens
 
 To perform a token exchange, grab a JWT from somewhere and add its issuer and JWKS URI to the `oauth.subjectTokenIssuers` section of your config file. Then, try running the following:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,10 @@ services:
         source: ./dmv.example.yaml
         target: /etc/dmv/dmv.yaml
         read_only: true
+      - type: bind
+        source: ./tests/data/privkey.pem
+        target: /etc/dmv/privkey.pem
+        read_only: true
       - type: volume
         source: audit-log
         target: /tmp


### PR DESCRIPTION
This auto-generates a private key in the `tests/data` directory allowing
for the `docker-up` makefile target to work out of the box and enable
easy testing.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
