### PR TITLE
Add storage engine

### DIFF
--- a/dmv.example.yaml
+++ b/dmv.example.yaml
@@ -3,9 +3,6 @@ server:
 oauth:
   issuer: "https://dmv.infratographer.com/"
   accessTokenLifespan: 100
-  subjectTokenIssuers:
-    - name: "https://auth.example.com/"
-      jwksURI: "https://auth.example.com/.well-known/jwks.json"
   secret: abcd1234abcd1234abcd1234abcd1234
   privateKeys:
     - keyId: "test"
@@ -18,3 +15,10 @@ otel:
   provider: stdout
   stdout:
     prettyPrint: true
+storage:
+  type: memory
+  memory:
+    issuers:
+      - name: "Example"
+        uri: "https://auth.example.com/"
+        jwksURI: "https://auth.example.com/.well-known/jwks.json"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"go.infratographer.com/x/otelx"
 
 	"go.infratographer.com/dmv/pkg/fositex"
+	"go.infratographer.com/dmv/pkg/storage"
 )
 
 // Config is the configuration for the application.
@@ -15,4 +16,5 @@ var Config struct {
 	Logging loggingx.Config
 	OAuth   fositex.Config
 	OTel    otelx.Config
+	Storage storage.Config
 }

--- a/pkg/api/v1/doc.go
+++ b/pkg/api/v1/doc.go
@@ -1,0 +1,2 @@
+// Package v1 contains top-level types and functions for DMV.
+package v1

--- a/pkg/api/v1/errors.go
+++ b/pkg/api/v1/errors.go
@@ -1,0 +1,12 @@
+package v1
+
+import "fmt"
+
+// ErrorIssuerNotFound represents an error condition where a given issuer was not found.
+type ErrorIssuerNotFound struct {
+	URI string
+}
+
+func (e *ErrorIssuerNotFound) Error() string {
+	return fmt.Sprintf("issuer '%s' not found", e.URI)
+}

--- a/pkg/api/v1/errors.go
+++ b/pkg/api/v1/errors.go
@@ -7,6 +7,6 @@ type ErrorIssuerNotFound struct {
 	URI string
 }
 
-func (e *ErrorIssuerNotFound) Error() string {
+func (e ErrorIssuerNotFound) Error() string {
 	return fmt.Sprintf("issuer '%s' not found", e.URI)
 }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1,0 +1,20 @@
+package v1
+
+import "context"
+
+// Issuer represents a token issuer.
+type Issuer struct {
+	// ID represents the ID of the issuer in DMV.
+	ID string
+	// Name represents the human-readable name of the issuer.
+	Name string
+	// URI represents the issuer URI as found in the "iss" claim of a JWT.
+	URI string
+	// JWKSURI represents the URI where the issuer's JWKS lives. Must be accessible by DMV.
+	JWKSURI string
+}
+
+// IssuerService represents a service for managing issuers.
+type IssuerService interface {
+	GetByURI(ctx context.Context, uri string) (*Issuer, error)
+}

--- a/pkg/fositex/config.go
+++ b/pkg/fositex/config.go
@@ -18,12 +18,6 @@ const (
 	PrivateKeyTypeSymmetric PrivateKeyType = "symmetric"
 )
 
-// Issuer represents a configurable JWT issuer.
-type Issuer struct {
-	Name    string
-	JWKSURI string
-}
-
 // PrivateKeyType represents a key type (public or symmetric)
 type PrivateKeyType string
 
@@ -38,7 +32,6 @@ type PrivateKey struct {
 type Config struct {
 	Issuer              string
 	AccessTokenLifespan int
-	SubjectTokenIssuers []Issuer
 	Secret              string
 	// When configuring an OAuth provider, the first private key will be used to sign
 	// JWTs.

--- a/pkg/fositex/doc.go
+++ b/pkg/fositex/doc.go
@@ -1,0 +1,2 @@
+// Package fositex contains types and functions for an opinionated Fosite server implementation.
+package fositex

--- a/pkg/jwks/doc.go
+++ b/pkg/jwks/doc.go
@@ -1,0 +1,2 @@
+// Package jwks contains types and functions for managing JSON Web Key Signatures (JWKS).
+package jwks

--- a/pkg/jwks/strategy.go
+++ b/pkg/jwks/strategy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	v1 "go.infratographer.com/dmv/pkg/api/v1"
 	"go.infratographer.com/dmv/pkg/fositex"
 )
 
@@ -14,28 +15,23 @@ var (
 )
 
 type issuerJWKSURIStrategy struct {
-	issuerURIs map[string]string
+	issuerSvc v1.IssuerService
 }
 
 // NewIssuerJWKSURIStrategy creates a new fosite.IssuerJWKSURIStrategy.
-func NewIssuerJWKSURIStrategy(issuers []fositex.Issuer) fositex.IssuerJWKSURIStrategy {
-	issuerURIs := make(map[string]string)
-	for _, iss := range issuers {
-		issuerURIs[iss.Name] = iss.JWKSURI
-	}
-
+func NewIssuerJWKSURIStrategy(issuerSvc v1.IssuerService) fositex.IssuerJWKSURIStrategy {
 	out := issuerJWKSURIStrategy{
-		issuerURIs: issuerURIs,
+		issuerSvc: issuerSvc,
 	}
 
 	return out
 }
 
 func (s issuerJWKSURIStrategy) GetIssuerJWKSURI(ctx context.Context, iss string) (string, error) {
-	jwksURI, ok := s.issuerURIs[iss]
-	if !ok {
-		return "", fmt.Errorf("%w: %s", ErrUnknownIssuer, iss)
+	issuer, err := s.issuerSvc.GetByURI(ctx, iss)
+	if err != nil {
+		return "", err
 	}
 
-	return jwksURI, nil
+	return issuer.JWKSURI, nil
 }

--- a/pkg/rfc8693/doc.go
+++ b/pkg/rfc8693/doc.go
@@ -1,0 +1,2 @@
+// Package rfc8693 contains types and functions for an RFC 8693 Token Exchange service.
+package rfc8693

--- a/pkg/routes/doc.go
+++ b/pkg/routes/doc.go
@@ -1,0 +1,2 @@
+// Package routes contains route handlers and logic for DMV.
+package routes

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -1,0 +1,14 @@
+package storage
+
+import v1 "go.infratographer.com/dmv/pkg/api/v1"
+
+// MemoryConfig represents the configuration for in-memory DMV storage.
+type MemoryConfig struct {
+	Issuers []v1.Issuer
+}
+
+// Config represents the storage configuration for DMV.
+type Config struct {
+	Type   EngineType
+	Memory MemoryConfig
+}

--- a/pkg/storage/doc.go
+++ b/pkg/storage/doc.go
@@ -1,0 +1,2 @@
+// Package storage contains types and functions for managing data storage in DMV.
+package storage

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	v1 "go.infratographer.com/dmv/pkg/api/v1"
+)
+
+const (
+	// EngineTypeMemory represents an in-memory storage engine.
+	EngineTypeMemory EngineType = "memory"
+)
+
+// EngineType represents the type of DMV storage engine.
+type EngineType string
+
+// Engine represents a storage engine.
+type Engine interface {
+	v1.IssuerService
+}
+
+// NewEngine creates a new storage engine based on the given config.
+func NewEngine(config Config) (Engine, error) {
+	switch config.Type {
+	case "":
+		return nil, ErrorMissingEngineType
+	case EngineTypeMemory:
+		issSvc, err := newMemoryIssuerService(config.Memory)
+		if err != nil {
+			return nil, err
+		}
+
+		out := &memoryEngine{
+			memoryIssuerService: issSvc,
+		}
+
+		return out, nil
+	default:
+		err := &ErrorUnknownEngineType{
+			engineType: config.Type,
+		}
+
+		return nil, err
+	}
+}

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -1,0 +1,15 @@
+package storage
+
+import "fmt"
+
+// ErrorMissingEngineType represents an error where no engine type was provided.
+var ErrorMissingEngineType = fmt.Errorf("missing engine type")
+
+// ErrorUnknownEngineType represents an error where an invalid engine type was provided.
+type ErrorUnknownEngineType struct {
+	engineType EngineType
+}
+
+func (e *ErrorUnknownEngineType) Error() string {
+	return fmt.Sprintf("unknown engine type '%s'", e.engineType)
+}

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -33,7 +33,7 @@ func newMemoryIssuerService(config MemoryConfig) (*memoryIssuerService, error) {
 func (s *memoryIssuerService) GetByURI(ctx context.Context, uri string) (*v1.Issuer, error) {
 	iss, ok := s.issuers[uri]
 	if !ok {
-		err := &v1.ErrorIssuerNotFound{
+		err := v1.ErrorIssuerNotFound{
 			URI: uri,
 		}
 

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -1,0 +1,44 @@
+package storage
+
+import (
+	"context"
+
+	v1 "go.infratographer.com/dmv/pkg/api/v1"
+)
+
+type memoryEngine struct {
+	*memoryIssuerService
+}
+
+// memoryIssuerService represents an in-memory issuer service.
+type memoryIssuerService struct {
+	issuers map[string]v1.Issuer
+}
+
+// newMemoryIssuerService creates a new in-memory issuer service.
+func newMemoryIssuerService(config MemoryConfig) (*memoryIssuerService, error) {
+	issuerMap := make(map[string]v1.Issuer, len(config.Issuers))
+	for _, iss := range config.Issuers {
+		issuerMap[iss.URI] = iss
+	}
+
+	out := &memoryIssuerService{
+		issuers: issuerMap,
+	}
+
+	return out, nil
+}
+
+// GetByURI looks up the given issuer by URI, returning the issuer if one exists.
+func (s *memoryIssuerService) GetByURI(ctx context.Context, uri string) (*v1.Issuer, error) {
+	iss, ok := s.issuers[uri]
+	if !ok {
+		err := &v1.ErrorIssuerNotFound{
+			URI: uri,
+		}
+
+		return nil, err
+	}
+
+	return &iss, nil
+}

--- a/pkg/storage/memory_test.go
+++ b/pkg/storage/memory_test.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "go.infratographer.com/dmv/pkg/api/v1"
+)
+
+func TestMemoryIssuerService(t *testing.T) {
+	type testResult struct {
+		iss *v1.Issuer
+		err error
+	}
+
+	type testCase struct {
+		name    string
+		input   string
+		checkFn func(*testing.T, testResult)
+	}
+
+	issuer := v1.Issuer{
+		ID:      "abcd1234",
+		Name:    "Example",
+		URI:     "https://example.com/",
+		JWKSURI: "https://example.com/.well-known/jwks.json",
+	}
+
+	testCases := []testCase{
+		{
+			name:  "NotFound",
+			input: "https://evil.biz/",
+			checkFn: func(t *testing.T, res testResult) {
+				expErr := v1.ErrorIssuerNotFound{
+					URI: "https://evil.biz/",
+				}
+
+				assert.ErrorIs(t, expErr, res.err)
+			},
+		},
+		{
+			name:  "Success",
+			input: "https://example.com/",
+			checkFn: func(t *testing.T, res testResult) {
+				assert.Nil(t, res.err)
+				assert.Equal(t, &issuer, res.iss)
+			},
+		},
+	}
+
+	config := MemoryConfig{
+		Issuers: []v1.Issuer{
+			issuer,
+		},
+	}
+
+	issSvc, err := newMemoryIssuerService(config)
+	assert.Nil(t, err)
+
+	for _, testCase := range testCases {
+		iss, err := issSvc.GetByURI(context.Background(), testCase.input)
+
+		result := testResult{
+			iss: iss,
+			err: err,
+		}
+
+		testCase.checkFn(t, result)
+	}
+}


### PR DESCRIPTION
This commit introduces the concept of a storage engine in DMV, as well as a reference in-memory implementation of issuer storage. Leaving subject token issuers as a Fosite-specific configuration item yielded a number of issues, and introducing a new set of storage engine interfaces allows us to separate data persistence from OAuth service implementation using either in-memory static data or, in the future, a database.
