### PR TITLE
Add .ssh directory for vscode user in dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,9 @@
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.19-bullseye
 
 USER vscode
+
+RUN mkdir /home/vscode/.ssh && \
+    chown vscode:vscode /home/vscode/.ssh && \
+    chmod 0700 /home/vscode/.ssh
+
 WORKDIR /workspace

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - type: bind
         source: ~/.ssh/authorized_keys
         target: /home/vscode/.ssh/authorized_keys
+        read_only: true
     networks:
       dmvnet:
 


### PR DESCRIPTION
This was an uncommitted oversight in the original devcontainers branch. When bind mounting ~/.ssh/authorized_keys in the container, the file itself and ~/.ssh are owned by root, meaning operations that require writing to ~/.ssh fail (e.g., trusting hosts). This PR updates the dev container Dockerfile to explicitly create this directory and set the owner to vscode.

As an additional precaution, ~/.ssh/authorized_keys is mounted as read-only to prevent accidental or malicious mangling of authorized keys on the host.

Signed-off-by: John Schaeffer <jschaeffer@equinix.com>